### PR TITLE
Fix broken docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Using Effect with Remix
 
 - [Remix Docs](https://remix.run/docs)
-- [Effect Docs](https://effect.website/docs)
+- [Effect Docs](https://effect.website/docs/introduction)
 - [Vite Docs](https://vitejs.dev/guide/)
 
 ## Project Goals


### PR DESCRIPTION
The effect.website/docs throws a 404 when navigating to the root, so changing this link to the introduction fixes it